### PR TITLE
Uses context manager for opening files in tests

### DIFF
--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -11,13 +11,15 @@ class SelfTestCase(unittest.TestCase):
     def testParse(self):
         srcs = glob.glob(os.path.join(gast.__path__[0], '*.py'))
         for src_py in srcs:
-            content = open(src_py).read()
+            with open(src_py) as f:
+                content = f.read()
             gast.parse(content)
 
     def testCompile(self):
         srcs = glob.glob(os.path.join(gast.__path__[0], '*.py'))
         for src_py in srcs:
-            content = open(src_py).read()
+            with open(src_py) as f:
+                content = f.read()
             gnode = gast.parse(content)
             compile(gast.gast_to_ast(gnode), src_py, 'exec')
 


### PR DESCRIPTION
This commit corrects a warning issued in the unit tests when a file is
opened with the `open()` built-in function without closing the file.