### PR TITLE
include the license file in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include tests *.py
+include LICENSE


### PR DESCRIPTION
Currently the `LICENSE` file isn't included in the source tarball on PyPI