### PR TITLE
Drop support for EOL Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -43,10 +43,6 @@ Version Compatibility
 GAST is tested using ``tox`` and Travis on the following Python versions:
 
 - 2.7
-- 3.0
-- 3.1
-- 3.2
-- 3.3
 - 3.4
 - 3.5
 - 3.6

--- a/gast/ast3.py
+++ b/gast/ast3.py
@@ -55,33 +55,6 @@ class Ast3ToGAst(AstToGAst):
             ast.copy_location(new_node, node)
             return new_node
 
-    if 2 <= sys.version_info.minor <= 3:
-
-        def _make_annotated_arg(self, parent, identifier, annotation):
-            if identifier is None:
-                return None
-            new_node = gast.Name(
-                self._visit(identifier),
-                gast.Param(),
-                self._visit(annotation),
-            )
-            return ast.copy_location(new_node, parent)
-
-        def visit_arguments(self, node):
-            new_node = gast.arguments(
-                [self._visit(n) for n in node.args],
-                self._make_annotated_arg(node,
-                                         node.vararg,
-                                         self._visit(node.varargannotation)),
-                [self._visit(n) for n in node.kwonlyargs],
-                self._visit(node.kw_defaults),
-                self._make_annotated_arg(node,
-                                         node.kwarg,
-                                         self._visit(node.kwargannotation)),
-                self._visit(node.defaults),
-            )
-            return new_node
-
     if sys.version_info.minor < 6:
 
         def visit_comprehension(self, node):
@@ -162,42 +135,16 @@ class GAstToAst3(GAstToAst):
             )
             return ast.copy_location(new_node, node)
 
-    if 2 <= sys.version_info.minor <= 3:
-
-        def visit_arguments(self, node):
-            if node.vararg is None:
-                vararg = None
-                varargannotation = None
-            else:
-                vararg = node.vararg.id
-                varargannotation = self._visit(node.vararg.annotation)
-            if node.kwarg is None:
-                kwarg = None
-                kwargannotation = None
-            else:
-                kwarg = node.kwarg.id
-                kwargannotation = self._visit(node.kwarg.annotation)
-
-            new_node = ast.arguments(
-                [self._make_arg(n) for n in node.args],
-                vararg, varargannotation,
-                [self._make_arg(n) for n in node.kwonlyargs],
-                kwarg, kwargannotation,
-                self._visit(node.defaults),
-                self._visit(node.kw_defaults),
-            )
-            return new_node
-    else:
-        def visit_arguments(self, node):
-            new_node = ast.arguments(
-                [self._make_arg(n) for n in node.args],
-                self._make_arg(node.vararg),
-                [self._make_arg(n) for n in node.kwonlyargs],
-                self._visit(node.kw_defaults),
-                self._make_arg(node.kwarg),
-                self._visit(node.defaults),
-            )
-            return new_node
+    def visit_arguments(self, node):
+        new_node = ast.arguments(
+            [self._make_arg(n) for n in node.args],
+            self._make_arg(node.vararg),
+            [self._make_arg(n) for n in node.kwonlyargs],
+            self._visit(node.kw_defaults),
+            self._make_arg(node.kwarg),
+            self._visit(node.defaults),
+        )
+        return new_node
 
 
 def ast_to_gast(node):

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,12 @@ as produced by ``ast.parse`` from the standard ``ast`` module.''',
                    'License :: OSI Approved :: BSD License',
                    'Natural Language :: English',
                    'Programming Language :: Python :: 2',
-                   'Programming Language :: Python :: 3'],
+                   'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3',
+                   'Programming Language :: Python :: 3.4',
+                   'Programming Language :: Python :: 3.5',
+                   'Programming Language :: Python :: 3.6',
+                   ],
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       **kw
       )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py30,py31,py32,py33,py34,py35,py36
+envlist = py27,py34,py35,py36
 [testenv]
 deps =
     astunparse


### PR DESCRIPTION
Python 2.6 and 3.0-3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

They're also little used.

Here's the pip installs for GAST from PyPI for July 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  52.51% |        217,780 |
| 3.6            |  29.71% |        123,217 |
| 3.5            |  15.76% |         65,377 |
| 3.4            |   1.64% |          6,806 |
| 3.7            |   0.37% |          1,539 |
| 3.3            |   0.01% |             39 |
| Total          |         |        414,758 |

Source: `pypinfo --start-date 2018-07-01 --end-date 2018-07-31 --percent --markdown gast pyversion`

This PR also adds `python_requires` to help pip, and updates the Trove classifiers.