### PR TITLE
Update readme to reflect testing on 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ GAST is tested using ``tox`` and Travis on the following Python versions:
 - 3.4
 - 3.5
 - 3.6
+- 3.7
 
 
 AST Changes


### PR DESCRIPTION
I'm assuming you're testing 3.7 now because it's in the tox.ini https://github.com/serge-sans-paille/gast/blob/master/tox.ini#L2