### PR TITLE
Fix conversion of arguments nodes in Python 3.8

### DIFF
--- a/gast/ast3.py
+++ b/gast/ast3.py
@@ -382,12 +382,16 @@ class GAstToAst3(GAstToAst):
                       self._make_arg(node.kwarg),
                       self._visit(node.defaults), ]
         if sys.version_info.minor >= 8:
-            extra_args.insert(0, [self._make_arg(arg) for arg in
-                                  node.posonlyargs])
-        new_node = ast.arguments(
-            [self._make_arg(n) for n in node.args],
-            *extra_args
-        )
+            new_node = ast.arguments(
+                [self._make_arg(arg) for arg in node.posonlyargs],
+                [self._make_arg(n) for n in node.args],
+                *extra_args
+            )
+        else:
+            new_node = ast.arguments(
+                [self._make_arg(n) for n in node.args],
+                *extra_args
+            )
         return new_node
 
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -96,6 +96,20 @@ class CompatTestCase(unittest.TestCase):
                         "[TypeIgnore(lineno=1, tag='[excuse]')])")
                 self.assertEqual(gast.dump(tree), norm)
 
+            def test_PosonlyArgs(self):
+                code = 'def foo(a, /, b): pass'
+                tree = gast.parse(code, type_comments=True)
+                compile(gast.gast_to_ast(tree), '<test>', 'exec')
+                norm = ("Module(body=[FunctionDef(name='foo', args=arguments("
+                        "args=[Name(id='b', ctx=Param(), annotation=None, "
+                        "type_comment=None)], posonlyargs=[Name(id='a', "
+                        "ctx=Param(), annotation=None, type_comment=None)], "
+                        "vararg=None, kwonlyargs=[], kw_defaults=[], "
+                        "kwarg=None, defaults=[]), body=[Pass()], "
+                        "decorator_list=[], returns=None, type_comment=None)"
+                        "], type_ignores=[])")
+                self.assertEqual(gast.dump(tree), norm)
+
         else:
 
             def test_Bytes(self):


### PR DESCRIPTION
`ast.arguments` changes in 3.8, taking posonlyargs as first argument, with `args` becoming the second.