### PR TITLE
Support Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 install: pip install tox-travis
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,12 @@ AST Changes
 Python3
 *******
 
-The AST used by GAST is the same as the one used in Python3.8, with the
+The AST used by GAST is the same as the one used in Python3.9, with the
 notable exception of ``ast.arg`` being replaced by an ``ast.Name`` with an
 ``ast.Param`` context.
+
+For minor version before 3.9, please note that ``ExtSlice`` and ``Index`` are
+not used.
 
 For minor version before 3.8, please note that ``Ellipsis``, ``Num``, ``Str``,
 ``Bytes`` and ``NamedConstant`` are represented as ``Constant``.

--- a/gast/gast.py
+++ b/gast/gast.py
@@ -218,9 +218,9 @@ _nodes = (
     ('Param', ((), (), (expr_context,))),
 
     # slice
-    ('Slice', (('lower', 'upper', 'step'), (), (slice,))),
-    ('ExtSlice', (('dims',), (), (slice,))),
-    ('Index', (('value',), (), (slice,))),
+    ('Slice', (('lower', 'upper', 'step'),
+               ('lineno', 'col_offset', 'end_lineno', 'end_col_offset',),
+               (slice,))),
 
     # boolop
     ('And', ((), (), (boolop,))),
@@ -273,7 +273,9 @@ _nodes = (
                     'kw_defaults', 'kwarg', 'defaults'), (), (AST,))),
 
     # keyword
-    ('keyword', (('arg', 'value'), (), (AST,))),
+    ('keyword', (('arg', 'value'),
+                 ('lineno', 'col_offset', 'end_lineno', 'end_col_offset'),
+                 (AST,))),
 
     # alias
     ('alias', (('name', 'asname'), (), (AST,))),
@@ -374,7 +376,7 @@ def increment_lineno(node, n=1):
     """
     for child in walk(node):
         if 'lineno' in child._attributes:
-            child.lineno = getattr(child, 'lineno', 0) + n
+            child.lineno = (getattr(child, 'lineno', 0) or 0) + n
         if 'end_lineno' in child._attributes:
-            child.end_lineno = getattr(child, 'end_lineno', 0) + n
+            child.end_lineno = (getattr(child, 'end_lineno', 0) or 0) + n
     return node

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
     kw = {}
 
 setup(name='gast',  # gast, daou naer!
-      version='0.3.3',
+      version='0.4.0',
       packages=['gast'],
       description='Python AST that abstracts the underlying Python version',
       long_description='''

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -252,12 +252,13 @@ class CompatTestCase(unittest.TestCase):
                 "], posonlyargs=[], vararg=None, kwonlyargs=[], kw_defaults=[]"
                 ", kwarg=None, defaults=[]), body=[Expr(value=Subscript(value="
                 "Name(id='a', ctx=Load(), annotation=None, type_comment=None)"
-                ", slice=Index(value=Constant(value=1, kind=None)), ctx=Load()"
+                ", slice=Constant(value=1, kind=None), ctx=Load()"
                 "))], decorator_list=[], returns=None, type_comment=None)]"
                 ", type_ignores=[])")
         self.assertEqual(gast.dump(tree), norm)
 
     def test_ExtSlice(self):
+        self.maxDiff = None
         code = 'def foo(a): a[:,:]'
         tree = gast.parse(code)
         compile(gast.gast_to_ast(tree), '<test>', 'exec')
@@ -266,13 +267,14 @@ class CompatTestCase(unittest.TestCase):
                 "], posonlyargs=[], vararg=None, kwonlyargs=[], kw_defaults=[]"
                 ", kwarg=None, defaults=[]), body=[Expr(value=Subscript(value="
                 "Name(id='a', ctx=Load(), annotation=None, type_comment=None)"
-                ", slice=ExtSlice(dims=[Slice(lower=None, upper=None, step="
-                "None), Slice(lower=None, upper=None, step=None)]), ctx=Load()"
-                "))], decorator_list=[], returns=None, type_comment=None)], "
-                "type_ignores=[])")
+                ", slice=Tuple(elts=[Slice(lower=None, upper=None, step="
+                "None), Slice(lower=None, upper=None, step=None)], ctx=Load())"
+                ", ctx=Load()))], decorator_list=[], returns=None, "
+                "type_comment=None)], type_ignores=[])")
         self.assertEqual(gast.dump(tree), norm)
 
     def test_ExtSlices(self):
+        self.maxDiff = None
         code = 'def foo(a): a[1,:]'
         tree = gast.parse(code)
         compile(gast.gast_to_ast(tree), '<test>', 'exec')
@@ -281,10 +283,10 @@ class CompatTestCase(unittest.TestCase):
                 "], posonlyargs=[], vararg=None, kwonlyargs=[], kw_defaults=[]"
                 ", kwarg=None, defaults=[]), body=[Expr(value=Subscript(value="
                 "Name(id='a', ctx=Load(), annotation=None, type_comment=None)"
-                ", slice=ExtSlice(dims=[Index(value=Constant(value=1, kind="
-                "None)), Slice(lower=None, upper=None, step=None)]), ctx=Load"
-                "()))], decorator_list=[], returns=None, type_comment=None)]"
-                ", type_ignores=[])")
+                ", slice=Tuple(elts=[Constant(value=1, kind="
+                "None), Slice(lower=None, upper=None, step=None)], ctx=Load())"
+                ", ctx=Load()))], decorator_list=[], returns=None, "
+                "type_comment=None)], type_ignores=[])")
         self.assertEqual(gast.dump(tree), norm)
 
     def test_Ellipsis(self):
@@ -297,8 +299,8 @@ class CompatTestCase(unittest.TestCase):
                 "], posonlyargs=[], vararg=None, kwonlyargs=[], kw_defaults=[]"
                 ", kwarg=None, defaults=[]), body=[Expr(value=Subscript(value="
                 "Name(id='a', ctx=Load(), annotation=None, type_comment=None)"
-                ", slice=Index(value=Constant(value=Ellipsis, kind=None)), ctx"
-                "=Load()))], decorator_list=[], returns=None, type_comment="
+                ", slice=Constant(value=Ellipsis, kind=None), ctx=Load()))], "
+                "decorator_list=[], returns=None, type_comment="
                 "None)], type_ignores=[])")
         self.assertEqual(gast.dump(tree), norm)
 
@@ -312,8 +314,8 @@ class CompatTestCase(unittest.TestCase):
                 "], posonlyargs=[], vararg=None, kwonlyargs=[], kw_defaults=[]"
                 ", kwarg=None, defaults=[]), body=[Expr(value=Subscript(value="
                 "Name(id='a', ctx=Load(), annotation=None, type_comment=None)"
-                ", slice=Index(value=Tuple(elts=[Constant(value=1, kind=None)"
-                ", Constant(value=Ellipsis, kind=None)], ctx=Load())), ctx="
+                ", slice=Tuple(elts=[Constant(value=1, kind=None)"
+                ", Constant(value=Ellipsis, kind=None)], ctx=Load()), ctx="
                 "Load()))], decorator_list=[], returns=None, type_comment="
                 "None)], type_ignores=[])")
         self.assertEqual(gast.dump(tree), norm)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38
+envlist = py27,py34,py35,py36,py37,py38,py39
 [testenv]
 deps =
     astunparse


### PR DESCRIPTION
Most important changes: ExtSlice and Index are no longer used.