### PR TITLE
Separate linting toxenv from testing toxenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ python:
   - "3.7"
   - "3.8"
   - "3.9-dev"
+jobs:
+  include:
+  - python: "3.8"
+    env: TOXENV=lint
 install: pip install tox-travis
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,15 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38,py39
+envlist = py27,py34,py35,py36,py37,py38,py39,lint
+
 [testenv]
 deps =
     astunparse
+    pytest
+commands=pytest {posargs}
+
+[testenv:lint]
+deps =
+    astunparse
     pytest-pep8
-commands=py.test --pep8
+    pytest < 5
+commands=pytest --pep8 -m pep8


### PR DESCRIPTION
This way, I can run onyl actuall tests in Fedora.
Also pytest-pep8 does not work with recent pytest versions.