### PR TITLE
Cleanup and optimize the way gast builds its AST

### DIFF
--- a/gast/ast3.py
+++ b/gast/ast3.py
@@ -9,8 +9,7 @@ class Ast3ToGAst(AstToGAst):
 
         def visit_ExtSlice(self, node):
             new_node = gast.Tuple(self._visit(node.dims), gast.Load())
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_Index(self, node):
             return self._visit(node.value)
@@ -39,8 +38,7 @@ class Ast3ToGAst(AstToGAst):
                 node.n,
                 None,
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_Ellipsis(self, node):
             new_node = gast.Constant(
@@ -56,16 +54,14 @@ class Ast3ToGAst(AstToGAst):
                 node.s,
                 None,
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_Bytes(self, node):
             new_node = gast.Constant(
                 node.s,
                 None,
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_FunctionDef(self, node):
             new_node = gast.FunctionDef(
@@ -76,8 +72,7 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.returns),
                 None,  # type_comment
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_AsyncFunctionDef(self, node):
             new_node = gast.AsyncFunctionDef(
@@ -88,8 +83,7 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.returns),
                 None,  # type_comment
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_For(self, node):
             new_node = gast.For(
@@ -99,8 +93,7 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.orelse),
                 None,  # type_comment
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_AsyncFor(self, node):
             new_node = gast.AsyncFor(
@@ -110,8 +103,7 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.orelse),
                 None,  # type_comment
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_With(self, node):
             new_node = gast.With(
@@ -119,8 +111,7 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.body),
                 None,  # type_comment
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_AsyncWith(self, node):
             new_node = gast.AsyncWith(
@@ -128,8 +119,7 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.body),
                 None,  # type_comment
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_Call(self, node):
             if sys.version_info.minor < 5:
@@ -155,8 +145,7 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.args) + starred,
                 self._visit(node.keywords) + kwargs,
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_NameConstant(self, node):
             if node.value is None:
@@ -165,8 +154,7 @@ class Ast3ToGAst(AstToGAst):
                 new_node = gast.Constant(True, None)
             elif node.value is False:
                 new_node = gast.Constant(False, None)
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
         def visit_arguments(self, node):
             new_node = gast.arguments(
@@ -178,33 +166,30 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.kwarg),
                 self._visit(node.defaults),
             )
-            gast.copy_location(new_node, node)
-            return new_node
+            return gast.copy_location(new_node, node)
 
     def visit_Name(self, node):
         new_node = gast.Name(
-            self._visit(node.id),
+            node.id,  # micro-optimization here, don't call self._visit
             self._visit(node.ctx),
             None,
             None,
         )
-        ast.copy_location(new_node, node)
-        return new_node
+        return ast.copy_location(new_node, node)
 
     def visit_arg(self, node):
         if sys.version_info.minor < 8:
-            extra_args = [None]
+            extra_arg = None
         else:
-            extra_args = [self._visit(node.type_comment)]
+            extra_arg = self._visit(node.type_comment)
 
         new_node = gast.Name(
-            self._visit(node.arg),
+            node.arg,  # micro-optimization here, don't call self._visit
             gast.Param(),
             self._visit(node.annotation),
-            *extra_args  # type_comment
+            extra_arg  # type_comment
         )
-        ast.copy_location(new_node, node)
-        return new_node
+        return ast.copy_location(new_node, node)
 
     def visit_ExceptHandler(self, node):
         if node.name:
@@ -212,8 +197,7 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.type),
                 gast.Name(node.name, gast.Store(), None, None),
                 self._visit(node.body))
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
         else:
             return self.generic_visit(node)
 
@@ -255,8 +239,7 @@ class GAstToAst3(GAstToAst):
                 new_slice,
                 self._visit(node.ctx),
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
     def visit_Assign(self, node):
         new_node = ast.Assign(
@@ -264,8 +247,7 @@ class GAstToAst3(GAstToAst):
             self._visit(node.value),
         )
 
-        ast.copy_location(new_node, node)
-        return new_node
+        return ast.copy_location(new_node, node)
 
     if sys.version_info.minor < 8:
 
@@ -286,8 +268,7 @@ class GAstToAst3(GAstToAst):
                 new_node = ast.Str(node.value)
             else:
                 new_node = ast.Bytes(node.value)
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
     def _make_arg(self, node):
         if node is None:
@@ -310,8 +291,7 @@ class GAstToAst3(GAstToAst):
             self._visit(node.id),
             self._visit(node.ctx),
         )
-        ast.copy_location(new_node, node)
-        return new_node
+        return ast.copy_location(new_node, node)
 
     def visit_ExceptHandler(self, node):
         if node.name:
@@ -347,8 +327,7 @@ class GAstToAst3(GAstToAst):
                 self._visit(starargs),
                 self._visit(kwargs),
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
         def visit_ClassDef(self, node):
             self.generic_visit(node)
@@ -373,8 +352,7 @@ class GAstToAst3(GAstToAst):
                 self._visit(node.decorator_list),
                 self._visit(node.returns),
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
         def visit_AsyncFunctionDef(self, node):
             new_node = ast.AsyncFunctionDef(
@@ -384,8 +362,7 @@ class GAstToAst3(GAstToAst):
                 self._visit(node.decorator_list),
                 self._visit(node.returns),
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
         def visit_For(self, node):
             new_node = ast.For(
@@ -394,8 +371,7 @@ class GAstToAst3(GAstToAst):
                 self._visit(node.body),
                 self._visit(node.orelse),
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
         def visit_AsyncFor(self, node):
             new_node = ast.AsyncFor(
@@ -405,24 +381,21 @@ class GAstToAst3(GAstToAst):
                 self._visit(node.orelse),
                 None,  # type_comment
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
         def visit_With(self, node):
             new_node = ast.With(
                 self._visit(node.items),
                 self._visit(node.body),
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
         def visit_AsyncWith(self, node):
             new_node = ast.AsyncWith(
                 self._visit(node.items),
                 self._visit(node.body),
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
         def visit_Call(self, node):
             new_node = ast.Call(
@@ -430,8 +403,7 @@ class GAstToAst3(GAstToAst):
                 self._visit(node.args),
                 self._visit(node.keywords),
             )
-            ast.copy_location(new_node, node)
-            return new_node
+            return ast.copy_location(new_node, node)
 
     def visit_arguments(self, node):
         extra_args = [self._make_arg(node.vararg),

--- a/gast/astn.py
+++ b/gast/astn.py
@@ -7,24 +7,29 @@ def _generate_translators(to):
     class Translator(ast.NodeTransformer):
 
         def _visit(self, node):
-            if isinstance(node, list):
-                return [self._visit(n) for n in node]
-            elif isinstance(node, ast.AST):
+            if isinstance(node, ast.AST):
                 return self.visit(node)
+            elif isinstance(node, list):
+                return [self._visit(n) for n in node]
             else:
                 return node
 
         def generic_visit(self, node):
             cls = type(node).__name__
-            # handle nodes that are not part of the AST
-            if not hasattr(to, cls):
+            try:
+                new_node = getattr(to, cls)()
+            except AttributeError:
+                # handle nodes that are not part of the AST
                 return
-            new_node = getattr(to, cls)()
+
             for field in node._fields:
                 setattr(new_node, field, self._visit(getattr(node, field)))
-            for attr in getattr(node, '_attributes'):
-                if hasattr(node, attr):
+
+            for attr in node._attributes:
+                try:
                     setattr(new_node, attr, getattr(node, attr))
+                except AttributeError:
+                    pass
             return new_node
 
     return Translator

--- a/gast/gast.py
+++ b/gast/gast.py
@@ -12,25 +12,27 @@ except ImportError:
 
 
 def _make_node(Name, Fields, Attributes, Bases):
+    NBFields = len(Fields)
+
     def create_node(self, *args, **kwargs):
-        nbparam = len(args) + len(kwargs)
-        assert nbparam in (0, len(Fields)), \
-            "Bad argument number for {}: {}, expecting {}".\
-            format(Name, nbparam, len(Fields))
-        self._fields = Fields
-        self._attributes = Attributes
-        for argname, argval in zip(self._fields, args):
-            setattr(self, argname, argval)
-        for argname, argval in kwargs.items():
-            assert argname in Fields, \
-                    "Invalid Keyword argument for {}: {}".format(Name, argname)
-            setattr(self, argname, argval)
+        if args:
+            if len(args) != NBFields:
+                raise TypeError(
+                    "{} constructor takes either 0 or {} positional arguments".
+                    format(Name, NBFields))
+            for argname, argval in zip(Fields, args):
+                setattr(self, argname, argval)
+        if kwargs:
+            for argname, argval in kwargs.items():
+                setattr(self, argname, argval)
 
     setattr(_sys.modules[__name__],
             Name,
             type(Name,
                  Bases,
-                 {'__init__': create_node}))
+                 {'__init__': create_node,
+                  '_fields': Fields,
+                  '_attributes': Attributes}))
 
 
 _nodes = (


### PR DESCRIPTION
This gives a 5 to 10% speedup in ast generation depending on the input. As gast
relies on the tree generated by the ast module and does not create any sharing
with the original tree, we're slower, but that's what make it a clean and simple
module :-)