### PR TITLE
Test field count more accurately

### DIFF
--- a/gast/gast.py
+++ b/gast/gast.py
@@ -16,9 +16,9 @@ def _make_node(Name, Fields, Attributes, Bases):
 
     def create_node(self, *args, **kwargs):
         if args:
-            if len(args) != NBFields:
+            if len(args) + len([k for k in kwargs if k in Fields]) != NBFields:
                 raise TypeError(
-                    "{} constructor takes either 0 or {} positional arguments".
+                    "{} constructor takes either 0 or {} mandatory arguments".
                     format(Name, NBFields))
             for argname, argval in zip(Fields, args):
                 setattr(self, argname, argval)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -121,6 +121,16 @@ def foo(x=1, *args, **kwargs):
 
         self.assertEqual(vis.state, [6])
 
+    def test_NodeConstructor(self):
+        node0 = gast.Name()
+        load = gast.Load()
+        node1 = gast.Name('id', load, None, None)
+        node2 = gast.Name('id', load, None, type_comment=None)
+        with self.assertRaises(TypeError):
+            node1 = gast.Name('id')
+        for field in gast.Name._fields:
+            self.assertEqual(getattr(node1, field), getattr(node2, field))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allow either 0 or #fields arguments, with #fields honoring keyword arguments