### PR TITLE
Add support for Python 3.11 and test 3.12-dev

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-          python-version: [2.7, 3.6, 3.8, 3.9, 3.10-dev]
+          python-version: ["2.7", "3.6", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ GAST is tested using ``tox`` and Travis on the following Python versions:
 - 3.8
 - 3.9
 - 3.10
+- 3.11
 
 
 AST Changes

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ as produced by ``ast.parse`` from the standard ``ast`` module.''',
                    'Programming Language :: Python :: 3.8',
                    'Programming Language :: Python :: 3.9',
                    'Programming Language :: Python :: 3.10',
+                   'Programming Language :: Python :: 3.11',
                    ],
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       **kw

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38,py39,lint
+envlist = py{27,34,35,36,37,38,39,310, 311, 312},lint
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

Also test 3.12-dev.