### PR TITLE
Add missing `type_params` attribute for `ClassDef` node before Python3.12

### DIFF
--- a/gast/ast3.py
+++ b/gast/ast3.py
@@ -74,17 +74,6 @@ class Ast3ToGAst(AstToGAst):
             )
             return gast.copy_location(new_node, node)
 
-        def visit_ClassDef(self, node):
-            new_node = gast.ClassDef(
-                self._visit(node.name),
-                self._visit(node.bases),
-                self._visit(node.keywords),
-                self._visit(node.body),
-                self._visit(node.decorator_list),
-                [],  # type_params
-            )
-            return gast.copy_location(new_node, node)
-
         def visit_FunctionDef(self, node):
             new_node = gast.FunctionDef(
                 self._visit(node.name),
@@ -238,17 +227,6 @@ class Ast3ToGAst(AstToGAst):
 
     if 8 <= sys.version_info.minor < 12:
 
-        def visit_ClassDef(self, node):
-            new_node = gast.ClassDef(
-                self._visit(node.name),
-                self._visit(node.bases),
-                self._visit(node.keywords),
-                self._visit(node.body),
-                self._visit(node.decorator_list),
-                [],  # type_params
-            )
-            return gast.copy_location(new_node, node)
-
         def visit_FunctionDef(self, node):
             new_node = gast.FunctionDef(
                 self._visit(node.name),
@@ -269,6 +247,19 @@ class Ast3ToGAst(AstToGAst):
                 self._visit(node.decorator_list),
                 self._visit(node.returns),
                 self._visit(node.type_comment),
+                [],  # type_params
+            )
+            return gast.copy_location(new_node, node)
+
+    if sys.version_info.minor < 12:
+
+        def visit_ClassDef(self, node):
+            new_node = gast.ClassDef(
+                self._visit(node.name),
+                self._visit(node.bases),
+                self._visit(node.keywords),
+                self._visit(node.body),
+                self._visit(node.decorator_list),
                 [],  # type_params
             )
             return gast.copy_location(new_node, node)

--- a/gast/ast3.py
+++ b/gast/ast3.py
@@ -74,6 +74,17 @@ class Ast3ToGAst(AstToGAst):
             )
             return gast.copy_location(new_node, node)
 
+        def visit_ClassDef(self, node):
+            new_node = gast.ClassDef(
+                self._visit(node.name),
+                self._visit(node.bases),
+                self._visit(node.keywords),
+                self._visit(node.body),
+                self._visit(node.decorator_list),
+                [],  # type_params
+            )
+            return gast.copy_location(new_node, node)
+
         def visit_FunctionDef(self, node):
             new_node = gast.FunctionDef(
                 self._visit(node.name),
@@ -226,6 +237,18 @@ class Ast3ToGAst(AstToGAst):
             return ast.copy_location(new_node, node)
 
     if 8 <= sys.version_info.minor < 12:
+
+        def visit_ClassDef(self, node):
+            new_node = gast.ClassDef(
+                self._visit(node.name),
+                self._visit(node.bases),
+                self._visit(node.keywords),
+                self._visit(node.body),
+                self._visit(node.decorator_list),
+                [],  # type_params
+            )
+            return gast.copy_location(new_node, node)
+
         def visit_FunctionDef(self, node):
             new_node = gast.FunctionDef(
                 self._visit(node.name),

--- a/gast/ast3.py
+++ b/gast/ast3.py
@@ -226,7 +226,6 @@ class Ast3ToGAst(AstToGAst):
             return ast.copy_location(new_node, node)
 
     if 8 <= sys.version_info.minor < 12:
-
         def visit_FunctionDef(self, node):
             new_node = gast.FunctionDef(
                 self._visit(node.name),

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -458,6 +458,15 @@ class CompatTestCase(unittest.TestCase):
                 "None, type_params=[])], type_ignores=[])")
         self.assertEqual(dump(tree), norm)
 
+    def test_ClassDef(self):
+        code = 'class Foo: ...'
+        tree = gast.parse(code)
+        compile(gast.gast_to_ast(tree), '<test>', 'exec')
+        norm = ("Module(body=[ClassDef(name='Foo', bases=[], keywords=[], "
+                "body=[Expr(value=Constant(value=Ellipsis, kind=None))], "
+                "decorator_list=[], type_params=[])], type_ignores=[])")
+        self.assertEqual(dump(tree), norm)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -459,12 +459,12 @@ class CompatTestCase(unittest.TestCase):
         self.assertEqual(dump(tree), norm)
 
     def test_ClassDef(self):
-        code = 'class Foo: ...'
+        code = 'class Foo: pass'
         tree = gast.parse(code)
         compile(gast.gast_to_ast(tree), '<test>', 'exec')
         norm = ("Module(body=[ClassDef(name='Foo', bases=[], keywords=[], "
-                "body=[Expr(value=Constant(value=Ellipsis, kind=None))], "
-                "decorator_list=[], type_params=[])], type_ignores=[])")
+                "body=[Pass()], decorator_list=[], type_params=[])], "
+                "type_ignores=[])")
         self.assertEqual(dump(tree), norm)
 
 


### PR DESCRIPTION
Add missing `type_params` attribute for `ClassDef` node before Python 3.12.