### PR TITLE
Construct ast node with known fields to avoid deprecation warning in Python 3.13

### DIFF
--- a/gast/astn.py
+++ b/gast/astn.py
@@ -15,15 +15,17 @@ def _generate_translators(to):
                 return node
 
         def generic_visit(self, node):
-            cls = type(node).__name__
-            try:
-                new_node = getattr(to, cls)()
-            except AttributeError:
+            class_name = type(node).__name__
+            if not hasattr(to, class_name):
                 # handle nodes that are not part of the AST
                 return
-
-            for field in node._fields:
-                setattr(new_node, field, self._visit(getattr(node, field)))
+            cls = getattr(to, class_name)
+            new_node = cls(
+                **{
+                    field: self._visit(getattr(node, field))
+                    for field in node._fields
+                }
+            )
 
             for attr in node._attributes:
                 try:


### PR DESCRIPTION
When using `GAstToAst` in Python 3.13, there are too many of `DeprecationWarning`.

```
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: FunctionDef.__init__ missing 1 required positional argument: 'args'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: FunctionDef.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: ClassDef.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Attribute.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Attribute.__init__ missing 1 required positional argument: 'attr'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Constant.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Call.__init__ missing 1 required positional argument: 'func'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: keyword.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: For.__init__ missing 1 required positional argument: 'target'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: For.__init__ missing 1 required positional argument: 'iter'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'right'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'op'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'left'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Subscript.__init__ missing 1 required positional argument: 'slice'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Subscript.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Compare.__init__ missing 1 required positional argument: 'left'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'target'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'op'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
/workspace/Paddle/build/python/paddle/utils/gast/astn.py:51: DeprecationWarning: Expr.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
  new_node = getattr(to, cls)()
```

It can also be reproduced in the existing unittests

```
❯ uv run --with pytest -p 3.13 pytest
================================================================ test session starts =================================================================
platform darwin -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/nyakku/Projects/gast
collected 55 items                                                                                                                                   

tests/test_api.py ...............                                                                                                              [ 27%]
tests/test_compat.py ..............................                                                                                            [ 81%]
tests/test_py3_12.py ....                                                                                                                      [ 89%]
tests/test_self.py ...                                                                                                                         [ 94%]
tests/test_unparser.py ...                                                                                                                     [100%]

================================================================== warnings summary ==================================================================
tests/test_api.py::APITestCase::test_literal_eval_code
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Expression.__init__ missing 1 required positional argument: 'body'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_api.py: 2 warnings
tests/test_compat.py: 29 warnings
tests/test_py3_12.py: 2 warnings
tests/test_self.py: 1210 warnings
tests/test_unparser.py: 2 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Constant.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 11 warnings
tests/test_py3_12.py: 1 warning
tests/test_self.py: 218 warnings
tests/test_unparser.py: 1 warning
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: FunctionDef.__init__ missing 1 required positional argument: 'args'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 11 warnings
tests/test_py3_12.py: 1 warning
tests/test_self.py: 218 warnings
tests/test_unparser.py: 1 warning
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: FunctionDef.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 17 warnings
tests/test_py3_12.py: 2 warnings
tests/test_self.py: 415 warnings
tests/test_unparser.py: 1 warning
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Expr.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 3 warnings
tests/test_self.py: 1044 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Call.__init__ missing 1 required positional argument: 'func'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_Call
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Starred.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 2 warnings
tests/test_self.py: 29 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: keyword.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 1 warning
tests/test_py3_12.py: 1 warning
tests/test_self.py: 11 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: ClassDef.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 5 warnings
tests/test_py3_12.py: 2 warnings
tests/test_self.py: 55 warnings
tests/test_unparser.py: 1 warning
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Subscript.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 5 warnings
tests/test_py3_12.py: 2 warnings
tests/test_self.py: 55 warnings
tests/test_unparser.py: 1 warning
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Subscript.__init__ missing 1 required positional argument: 'slice'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_FormattedValue
tests/test_compat.py::CompatTestCase::test_JoinedStr
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: FormattedValue.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_FormattedValue
tests/test_compat.py::CompatTestCase::test_JoinedStr
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: FormattedValue.__init__ missing 1 required positional argument: 'conversion'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_MatchAs
tests/test_compat.py::CompatTestCase::test_MatchClass
tests/test_compat.py::CompatTestCase::test_MatchMapping
tests/test_compat.py::CompatTestCase::test_MatchOr
tests/test_compat.py::CompatTestCase::test_MatchSequence
tests/test_compat.py::CompatTestCase::test_MatchSingleton
tests/test_compat.py::CompatTestCase::test_MatchStar
tests/test_compat.py::CompatTestCase::test_MatchValue
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Match.__init__ missing 1 required positional argument: 'subject'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_MatchAs
tests/test_compat.py::CompatTestCase::test_MatchClass
tests/test_compat.py::CompatTestCase::test_MatchMapping
tests/test_compat.py::CompatTestCase::test_MatchOr
tests/test_compat.py::CompatTestCase::test_MatchSequence
tests/test_compat.py::CompatTestCase::test_MatchSingleton
tests/test_compat.py::CompatTestCase::test_MatchStar
tests/test_compat.py::CompatTestCase::test_MatchValue
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: match_case.__init__ missing 1 required positional argument: 'pattern'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_MatchAs
tests/test_compat.py::CompatTestCase::test_MatchClass
tests/test_compat.py::CompatTestCase::test_MatchOr
tests/test_compat.py::CompatTestCase::test_MatchOr
tests/test_compat.py::CompatTestCase::test_MatchStar
tests/test_compat.py::CompatTestCase::test_MatchValue
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: MatchValue.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_MatchClass
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: MatchClass.__init__ missing 1 required positional argument: 'cls'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_MatchSingleton
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: MatchSingleton.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_NamedExpr
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: NamedExpr.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_NamedExpr
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: NamedExpr.__init__ missing 1 required positional argument: 'target'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_TypeIgnore
tests/test_compat.py::CompatTestCase::test_TypeIgnore
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: TypeIgnore.__init__ missing 1 required positional argument: 'lineno'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py::CompatTestCase::test_TypeIgnore
tests/test_compat.py::CompatTestCase::test_TypeIgnore
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: TypeIgnore.__init__ missing 1 required positional argument: 'tag'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_compat.py: 1 warning
tests/test_self.py: 48 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: withitem.__init__ missing 1 required positional argument: 'context_expr'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_py3_12.py::Python3_12TestCase::test_generic_class
tests/test_py3_12.py::Python3_12TestCase::test_generic_function
tests/test_py3_12.py::Python3_12TestCase::test_generic_type_alias
tests/test_unparser.py::UnparserTestCase::test_TypeParameter
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: TypeVar.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_py3_12.py::Python3_12TestCase::test_generic_type_alias
tests/test_py3_12.py::Python3_12TestCase::test_type_alias
tests/test_unparser.py::UnparserTestCase::test_TypeParameter
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: TypeAlias.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_py3_12.py::Python3_12TestCase::test_generic_type_alias
tests/test_py3_12.py::Python3_12TestCase::test_type_alias
tests/test_unparser.py::UnparserTestCase::test_TypeParameter
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: TypeAlias.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 44 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: alias.__init__ missing 1 required positional argument: 'name'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 177 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: If.__init__ missing 1 required positional argument: 'test'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 83 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Compare.__init__ missing 1 required positional argument: 'left'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 1746 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Attribute.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 1746 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Attribute.__init__ missing 1 required positional argument: 'attr'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 32 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: For.__init__ missing 1 required positional argument: 'iter'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 32 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: For.__init__ missing 1 required positional argument: 'target'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 40 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: UnaryOp.__init__ missing 1 required positional argument: 'operand'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 40 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: UnaryOp.__init__ missing 1 required positional argument: 'op'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 51 warnings
tests/test_unparser.py: 1 warning
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'right'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 51 warnings
tests/test_unparser.py: 1 warning
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'left'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 51 warnings
tests/test_unparser.py: 1 warning
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: BinOp.__init__ missing 1 required positional argument: 'op'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 34 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: BoolOp.__init__ missing 1 required positional argument: 'op'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'target'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: AugAssign.__init__ missing 1 required positional argument: 'op'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: GeneratorExp.__init__ missing 1 required positional argument: 'elt'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 15 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: comprehension.__init__ missing 1 required positional argument: 'iter'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 15 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: comprehension.__init__ missing 1 required positional argument: 'target'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 15 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: comprehension.__init__ missing 1 required positional argument: 'is_async'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 20 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Lambda.__init__ missing 1 required positional argument: 'args'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py: 20 warnings
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Lambda.__init__ missing 1 required positional argument: 'body'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: DictComp.__init__ missing 1 required positional argument: 'value'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: DictComp.__init__ missing 1 required positional argument: 'key'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: While.__init__ missing 1 required positional argument: 'test'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: ListComp.__init__ missing 1 required positional argument: 'elt'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

tests/test_self.py::SelfTestCase::testCompile
  /Users/nyakku/Projects/gast/gast/astn.py:20: DeprecationWarning: Assert.__init__ missing 1 required positional argument: 'test'. This will become an error in Python 3.15.
    new_node = getattr(to, cls)()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 55 passed, 7707 warnings in 0.18s ==========================================================
```

This is because omitting optional fields was allowed in previous versions, but this was marked as deprecated in Python 3.13 and will be removed in 3.15[^1]

So I tried to construct the ast node directly using the known fields and it seems to work well.

```
❯ uv run --with pytest -p 3.13 pytest                                         
================================================================ test session starts =================================================================
platform darwin -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/nyakku/Projects/gast
collected 55 items                                                                                                                                   

tests/test_api.py ...............                                                                                                              [ 27%]
tests/test_compat.py ..............................                                                                                            [ 81%]
tests/test_py3_12.py ....                                                                                                                      [ 89%]
tests/test_self.py ...                                                                                                                         [ 94%]
tests/test_unparser.py ...                                                                                                                     [100%]

================================================================= 55 passed in 0.16s =================================================================
```

The changes have been tested at PaddlePaddle/Paddle#69232.

[^1]: https://docs.python.org/3/library/ast.html#ast.AST