### PR TITLE
Only pass existing attributes as keyword parameters in gast_to_ast

### DIFF
--- a/gast/astn.py
+++ b/gast/astn.py
@@ -24,6 +24,7 @@ def _generate_translators(to):
                 **{
                     field: self._visit(getattr(node, field))
                     for field in node._fields
+                    if hasattr(node, field)
                 }
             )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -195,6 +195,30 @@ def foo(x=1, *args, **kwargs):
         for field in gast.Name._fields:
             self.assertEqual(getattr(node1, field), getattr(node2, field))
 
+    def test_IncompleteNodeConstructor(self):
+        afd = gast.AsyncFunctionDef(
+                    name="f",
+                    args=gast.arguments(
+                        args=[],
+                        posonlyargs=[],
+                        vararg=None,
+                        kwonlyargs=[],
+                        kw_defaults=[],
+                        kwarg=None,
+                        defaults=[],
+                        ),
+                    body=[],
+                    decorator_list=[],
+                    returns=None,
+                    type_comment=None,
+                    #type_params=[],
+                    )
+        # Should not fail even if type_params is not set
+        afd_ast = gast.gast_to_ast(afd)
+        self.assertEqual(afd_ast.name, "f")
+        if hasattr(afd_ast, "type_params"):
+            self.assertEqual(afd_ast.type_params, [])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If some attribute is not set upon node creation, it is currently not set as a node attribute and so cannot be passed down when going back to ast.

This behavior has changed in recent ast version, we should probably handle that. It's for another PR though.

Fix #93