### PR TITLE
fix: filter out invalid fields when translating AST nodes

### DIFF
--- a/gast/astn.py
+++ b/gast/astn.py
@@ -20,11 +20,12 @@ def _generate_translators(to):
                 # handle nodes that are not part of the AST
                 return
             cls = getattr(to, class_name)
+            valid_fields = getattr(cls, '_fields', ())
             new_node = cls(
                 **{
                     field: self._visit(getattr(node, field))
                     for field in node._fields
-                    if hasattr(node, field)
+                    if hasattr(node, field) and field in valid_fields
                 }
             )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import unittest
 import ast
 import gast
 import sys
+import warnings
 
 
 def dump(node):
@@ -226,6 +227,20 @@ def foo(x=1, *args, **kwargs):
         self.assertEqual(afd_ast.name, "f")
         if hasattr(afd_ast, "type_params"):
             self.assertEqual(afd_ast.type_params, [])
+
+    def test_gast_to_ast_ignores_unknown_fields(self):
+        tree = gast.parse('obj.attr')
+        attr = tree.body[0].value
+        attr._fields = attr._fields + ('___pyct_anno',)
+        attr.___pyct_anno = object()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            ast_tree = gast.gast_to_ast(tree)
+
+        ast_attr = ast_tree.body[0].value
+        self.assertEqual(ast_attr.attr, 'attr')
+        self.assertFalse(hasattr(ast_attr, '___pyct_anno'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Python 3.15 deprecates passing arbitrary keyword arguments to AST node constructors (which triggers warnings in Python 3.11+).

In `astn.py`, `generic_visit` translates nodes by passing all fields from the source node's `_fields` directly to the target node constructor (`cls`). If the source node has been annotated with custom fields by external libraries (e.g., `___pyct_anno` added by Python Compiler Toolkits), these invalid fields are passed to the target constructor, triggering `DeprecationWarning` spam:

```
DeprecationWarning: Attribute.init got an unexpected keyword argument '___pyct_anno'. Support for arbitrary keyword arguments is deprecated and will be removed in Python 3.15.
```

This fix filters the keyword arguments passed to the target constructor `cls()` to only include fields that are explicitly defined in the target class's `_fields` (using `getattr(cls, '_fields', ())`). This prevents the deprecation warnings and ensures compatibility with Python 3.15.