### PR TITLE
Preserve assignment type comments when converting GAST back to AST

### DIFF
--- a/gast/ast3.py
+++ b/gast/ast3.py
@@ -53,7 +53,7 @@ class Ast3ToGAst(AstToGAst):
             new_node = gast.Assign(
                 self._visit(node.targets),
                 self._visit(node.value),
-                None,  # type_comment
+                self._visit(getattr(node, 'type_comment', None)),
             )
 
             gast.copy_location(new_node, node)
@@ -345,10 +345,17 @@ class GAstToAst3(GAstToAst):
             return ast.copy_location(new_node, node)
 
     def visit_Assign(self, node):
-        new_node = ast.Assign(
-            self._visit(node.targets),
-            self._visit(node.value),
-        )
+        if sys.version_info >= (3, 8):
+            new_node = ast.Assign(
+                self._visit(node.targets),
+                self._visit(node.value),
+                type_comment=self._visit(node.type_comment),
+            )
+        else:
+            new_node = ast.Assign(
+                self._visit(node.targets),
+                self._visit(node.value),
+            )
 
         return ast.copy_location(new_node, node)
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -109,6 +109,26 @@ class CompatTestCase(unittest.TestCase):
                         "[TypeIgnore(lineno=1, tag='[excuse]')])")
                 self.assertEqual(dump(tree), norm)
 
+            def test_AssignTypeCommentPreservedInGastToAst(self):
+                """Regression test: type_comment on Assign must survive gast->ast roundtrip.
+
+                Previously GAstToAst3.visit_Assign omitted the type_comment
+                argument, silently dropping annotations such as ``x = 1  # type: int``
+                on every gast-to-ast conversion (Python >= 3.8).
+                """
+                code = 'x = 1  # type: int'
+                # Parse with type_comment support so the annotation is captured
+                ast_tree = gast.parse(code, type_comments=True)
+                # Confirm the gast node carries the annotation
+                self.assertEqual(ast_tree.body[0].type_comment, 'int')
+                # Convert back to a standard ast tree
+                converted = gast.gast_to_ast(ast_tree)
+                # The type_comment must survive the roundtrip
+                self.assertEqual(converted.body[0].type_comment, 'int')
+                # Must also compile cleanly
+                compile(converted, '<test>', 'exec')
+
+
             def test_PosonlyArgs(self):
                 code = 'def foo(a, /, b): pass'
                 tree = gast.parse(code, type_comments=True)


### PR DESCRIPTION
While testing round-trip conversions, I noticed that assignment type comments are preserved when converting from `ast` to `gast`, but are lost when converting back from `gast` to `ast`.

The issue was in `GAstToAst3.visit_Assign`, where `ast.Assign` was rebuilt without forwarding the `type_comment` field. As a result, code parsed with `type_comments=True` would silently lose assignment type comments during a GAST → AST roundtrip.

Changes
- Updated `GAstToAst3.visit_Assign` in `gast/ast3.py` to pass the `type_comment` field when constructing `ast.Assign`.
- Added a regression test to ensure assignment type comments are preserved after converting from `gast` back to `ast`.

 Verification
Verified on Python 3.13. All tests pass, including the new regression test.