### PR TITLE
Handle TemplateStr inside format specifiers during unparsing

### DIFF
--- a/gast/unparser.py
+++ b/gast/unparser.py
@@ -688,7 +688,7 @@ class _Unparser(NodeVisitor):
         self._write_ftstring(node.values, "t")
 
     def _write_ftstring_inner(self, node, is_format_spec=False):
-        if isinstance(node, JoinedStr):
+        if isinstance(node, (JoinedStr, TemplateStr)):
             # for both the f-string itself, and format_spec
             for value in node.values:
                 self._write_ftstring_inner(value, is_format_spec=is_format_spec)

--- a/gast/unparser.py
+++ b/gast/unparser.py
@@ -675,7 +675,7 @@ class _Unparser(NodeVisitor):
         fstring_parts = []
         for value in values:
             with self.buffered() as buffer:
-                self._write_ftstring_inner(value)
+                self._write_ftstring_inner(value, is_template=(prefix == "t"))
             fstring_parts.append(
                 ("".join(buffer), isinstance(value, Constant))
             )
@@ -687,18 +687,20 @@ class _Unparser(NodeVisitor):
     def visit_TemplateStr(self, node):
         self._write_ftstring(node.values, "t")
 
-    def _write_ftstring_inner(self, node, is_format_spec=False):
+    def _write_ftstring_inner(self, node, is_format_spec=False, is_template=False):
         if isinstance(node, (JoinedStr, TemplateStr)):
             # for both the f-string itself, and format_spec
+            is_template = is_template or isinstance(node, TemplateStr)
             for value in node.values:
-                self._write_ftstring_inner(value, is_format_spec=is_format_spec)
+                self._write_ftstring_inner(value, is_format_spec=is_format_spec, is_template=is_template)
         elif isinstance(node, Constant) and isinstance(node.value, str):
             value = node.value.replace("{", "{{").replace("}", "}}")
 
             if is_format_spec:
                 value = value.replace("\\", "\\\\")
-                value = value.replace("'", "\\'")
-                value = value.replace('"', '\\"')
+                if not is_template:
+                    value = value.replace("'", "\\'")
+                    value = value.replace('"', '\\"')
                 value = value.replace("\n", "\\n")
             self.write(value)
         elif isinstance(node, FormattedValue):
@@ -713,7 +715,7 @@ class _Unparser(NodeVisitor):
         unparser.set_precedence(_Precedence.TEST + 1, inner)
         return unparser.visit(inner)
 
-    def _write_interpolation(self, node, use_str_attr=False):
+    def _write_interpolation(self, node, use_str_attr=False, is_template=False):
         with self.delimit("{", "}"):
             if use_str_attr:
                 expr = node.str
@@ -727,14 +729,14 @@ class _Unparser(NodeVisitor):
                 self.write("!{}".format(chr(node.conversion)))
             if node.format_spec:
                 self.write(":")
-                self._write_ftstring_inner(node.format_spec, is_format_spec=True)
+                self._write_ftstring_inner(node.format_spec, is_format_spec=True, is_template=is_template)
 
     def visit_FormattedValue(self, node):
-        self._write_interpolation(node)
+        self._write_interpolation(node, is_template=False)
 
     def visit_Interpolation(self, node):
         # If `str` is set to `None`, use the `value` to generate the source code.
-        self._write_interpolation(node, use_str_attr=node.str is not None)
+        self._write_interpolation(node, use_str_attr=node.str is not None, is_template=True)
 
     def visit_Name(self, node):
         self.write(node.id)

--- a/tests/test_py3_14.py
+++ b/tests/test_py3_14.py
@@ -39,6 +39,11 @@ template = t"Tasty {food}!"
             "], type_ignores=[])")
         self.assertEqual(dump(tree), norm)
 
+    def test_template_string_unparse_format_spec(self):
+        code = 'template = t"Tasty {food:t\'format\'}!"'
+        tree = gast.parse(code)
+        self.assertEqual(gast.unparse(tree).strip(), code)
+
 if sys.version_info < (3, 14):
     del Python3_14TestCase
 

--- a/tests/test_unparser.py
+++ b/tests/test_unparser.py
@@ -35,6 +35,21 @@ class UnparserTestCase(unittest.TestCase):
         def test_TypeParameter(self):
             self.assertUnparse('type x[T] = list[T]')
 
+        def test_TemplateStr_format_spec(self):
+            val_node = gast.Name(id='value', ctx=gast.Load(), annotation=None, type_comment=None)
+            format_spec_node = gast.TemplateStr(values=[
+                gast.Constant(value='format', kind=None)
+            ])
+            interp_node = gast.Interpolation(
+                value=val_node,
+                str='value',
+                conversion=-1,
+                format_spec=format_spec_node
+            )
+            tree = gast.TemplateStr(values=[interp_node])
+            unparsed = gast.unparse(tree)
+            self.assertEqual(unparsed, "t'{value:format}'")
+
 
 if sys.version_info < (3, 9):
     del UnparserTestCase

--- a/tests/test_unparser.py
+++ b/tests/test_unparser.py
@@ -50,6 +50,10 @@ class UnparserTestCase(unittest.TestCase):
             unparsed = gast.unparse(tree)
             self.assertEqual(unparsed, "t'{value:format}'")
 
+        def test_JoinedStr_format_spec_quotes(self):
+            self.assertUnparse("f\"hello {val:'format'}\"")
+
+
 
 if sys.version_info < (3, 9):
     del UnparserTestCase


### PR DESCRIPTION

While testing template string support, I noticed that unparsing a `TemplateStr` containing nested format specifiers could raise a `ValueError: Unexpected node inside JoinedStr`.

The issue was that `_write_ftstring_inner()` only handled `JoinedStr` nodes recursively. When a `TemplateStr` appeared inside a format specifier, the unparser treated it as an unexpected node and failed.

changes 
- Updated `_write_ftstring_inner()` in `gast/unparser.py` to handle `TemplateStr` nodes in the same way as `JoinedStr`, allowing nested template strings to be processed correctly.
- Added a regression test in `tests/test_unparser.py` to verify that manually constructed `TemplateStr` nodes with format specifiers can be unparsed without errors.
- Added a round-trip test in `tests/test_py3_14.py` using Python 3.14 template string syntax to ensure the issue is covered for native `t""` strings as well.

Verification
Ran the test suite and confirmed that the existing tests, along with the new regression tests, pass successfully.