### PR TITLE
Fix zip(strict=True) usage in pattern matching unparser

### DIFF
--- a/gast/unparser.py
+++ b/gast/unparser.py
@@ -1167,7 +1167,7 @@ class _Unparser(NodeVisitor):
             self.interleave(
                 lambda: self.write(", "),
                 write_key_pattern_pair,
-                zip(keys, node.patterns, strict=True),
+                zip(keys, node.patterns),
             )
             rest = node.rest
             if rest is not None:
@@ -1195,7 +1195,7 @@ class _Unparser(NodeVisitor):
                 self.interleave(
                     lambda: self.write(", "),
                     write_attr_pattern,
-                    zip(attrs, node.kwd_patterns, strict=True),
+                    zip(attrs, node.kwd_patterns),
                 )
 
     def visit_MatchAs(self, node):

--- a/tests/test_unparser.py
+++ b/tests/test_unparser.py
@@ -54,6 +54,22 @@ class UnparserTestCase(unittest.TestCase):
             self.assertUnparse("f\"hello {val:'format'}\"")
 
 
+    if sys.version_info >= (3, 10):
+
+        def test_MatchMapping(self):
+            self.assertUnparse('''
+match obj:
+    case {"x": 1}:
+        pass
+''')
+
+        def test_MatchClass(self):
+            self.assertUnparse('''
+match obj:
+    case Point(1, y=2):
+        pass
+''')
+
 
 if sys.version_info < (3, 9):
     del UnparserTestCase


### PR DESCRIPTION
While looking into the pattern matching unparser, I noticed that
`visit_MatchMapping` and `visit_MatchClass` use `zip(..., strict=True)`.

Since the `strict` argument was introduced in Python 3.10, these code paths can raise a `TypeError` when running on older supported Python versions.

The corresponding collections are already expected to have matching lengths, so removing `strict=True` preserves the current behavior while restoring compatibility.

Changes
- Remove `strict=True` from the `zip()` calls in `visit_MatchMapping` and `visit_MatchClass`
- Add regression tests for both code paths in `tests/test_unparser.py`

This keeps the existing behavior unchanged and avoids relying on a Python 3.10-only feature.